### PR TITLE
replace .URL with .RelPermalink

### DIFF
--- a/themes/cactus-plus/layouts/partials/latest-posts.html
+++ b/themes/cactus-plus/layouts/partials/latest-posts.html
@@ -2,10 +2,10 @@
     <h3>{{ .Site.Params.readMore | default "Read more" }}</h3>
 
     {{ $kind := where .Site.RegularPages "Section" "!=" "" }}
-    {{ $othr := where $kind "URL" "!=" .URL }}
+    {{ $othr := where $kind "RelPermalink" "!=" .RelPermalink }}
     {{ range first 10 $othr }}
         <li>
-            <a href="{{ .URL }}">{{ .LinkTitle }}<aside class="dates">{{ .Date.Format "Jan 2 2006" }}</aside></a>
+            <a href="{{ .RelPermalink }}">{{ .LinkTitle }}<aside class="dates">{{ .Date.Format "Jan 2 2006" }}</aside></a>
         </li>
     {{ end }}
 </ul>

--- a/themes/cactus-plus/layouts/partials/pagination.html
+++ b/themes/cactus-plus/layouts/partials/pagination.html
@@ -2,14 +2,14 @@
     {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
         {{ if .Paginator.HasPrev }}
         <span class="prev">
-            <a href="{{.Paginator.Prev.URL}}">
+            <a href="{{.Paginator.Prev.RelPermalink}}">
                 <span class="arrow">←</span> {{ with .Site.Params.newerPosts }}{{ . }}{{ else }}Newer Posts{{ end }}
             </a>
         </span>
         {{ end }}
         {{ if .Paginator.HasNext }}
         <span class="next">
-            <a href="{{.Paginator.Next.URL}}">
+            <a href="{{.Paginator.Next.RelPermalink}}">
                 {{ with .Site.Params.olderPosts }}{{ . }}{{ else }}Older Posts{{ end }} <span class="arrow">→</span>
             </a>
         </span>

--- a/themes/cactus-plus/layouts/partials/pagination.html
+++ b/themes/cactus-plus/layouts/partials/pagination.html
@@ -2,14 +2,14 @@
     {{ if or (.Paginator.HasPrev) (.Paginator.HasNext) }}
         {{ if .Paginator.HasPrev }}
         <span class="prev">
-            <a href="{{.Paginator.Prev.RelPermalink}}">
+            <a href="{{.Paginator.Prev.URL}}">
                 <span class="arrow">←</span> {{ with .Site.Params.newerPosts }}{{ . }}{{ else }}Newer Posts{{ end }}
             </a>
         </span>
         {{ end }}
         {{ if .Paginator.HasNext }}
         <span class="next">
-            <a href="{{.Paginator.Next.RelPermalink}}">
+            <a href="{{.Paginator.Next.URL}}">
                 {{ with .Site.Params.olderPosts }}{{ . }}{{ else }}Older Posts{{ end }} <span class="arrow">→</span>
             </a>
         </span>


### PR DESCRIPTION
fix warning "Page's .URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url."

find * -type f -exec sed -i '/s/.URL/.RelPermalink/g' {} \;